### PR TITLE
Start index before delete

### DIFF
--- a/cfn-status.gemspec
+++ b/cfn-status.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "aws-sdk-cloudformation"
 
-  spec.add_development_dependency "bundler", "~> 2.0"
-  spec.add_development_dependency "rake", "~> 10.0"
-  spec.add_development_dependency "rspec", "~> 3.0"
+  spec.add_development_dependency "bundler"
+  spec.add_development_dependency "rake", ">= 12.3.3"
+  spec.add_development_dependency "rspec", ">= 3.0"
 end

--- a/lib/cfn_status.rb
+++ b/lib/cfn_status.rb
@@ -23,7 +23,7 @@ class CfnStatus
       return true
     end
 
-    puts "The current status for the stack #{@stack_name.color(:green)} is #{stack.stack_status.color(:green)}"
+    puts "Stack #{@stack_name.color(:green)} Status: #{stack.stack_status.color(:green)}"
     if in_progress?
       puts "Stack events (tailing):"
       # tail all events until done
@@ -191,9 +191,14 @@ class CfnStatus
 
   # Should always find a "User Initiated" stack event when @last_shown_index is not set
   def start_index
+    start_index_before_delete = @options[:start_index_before_delete]
+
     @events.find_index do |event|
+      skip = start_index_before_delete && event["resource_status"] == "DELETE_IN_PROGRESS"
+
       event["resource_type"] == "AWS::CloudFormation::Stack" &&
-      event["resource_status_reason"] == "User Initiated"
+      event["resource_status_reason"] == "User Initiated" &&
+      !skip
     end
   end
 


### PR DESCRIPTION
It is helpful to skip the User Initiated DELETE_IN_PROGRESS event from created stack failure and show more events so the user can see the more useful errors.